### PR TITLE
Update psr/container dependency to 1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "mezzio/mezzio-helpers": "^5.9.0",
         "mezzio/mezzio-session-cache": "^1.7",
         "mlocati/ip-lib": "1.18",
-        "psr/container": "^1.0 || ^2.0",
+        "psr/container": "^1.1 || ^2.0",
         "symfony/cache": "^6.1.2",
         "symfony/translation": "^6.1"
     },


### PR DESCRIPTION
Fixes:
  Declaration of Zalt\Mock\SimpleServiceManager::get(string $id) must be
  compatible with Psr\Container\ContainerInterface::get($id) in
  src/Mock/SimpleServiceManager.php on line 34